### PR TITLE
Refactor the Makefiles under veo/

### DIFF
--- a/veo/2DConvolution/Makefile
+++ b/veo/2DConvolution/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = 2DConvolution kernel.so
 all:$(TARGET)
 
-2DConvolution:2DConvolution.o
+2DConvolution: 2DConvolution.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-2DConvolution.o:2DConvolution.cpp
+2DConvolution.o: 2DConvolution.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
 kernel.so:kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./2DConvolution $(PROBLEM_SIZE)

--- a/veo/2mm/Makefile
+++ b/veo/2mm/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = 2mm kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-2mm:2mm.o
+2mm: 2mm.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-2mm.o:2mm.cpp
+2mm.o: 2mm.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./2mm $(PROBLEM_SIZE)

--- a/veo/3DConvolution/Makefile
+++ b/veo/3DConvolution/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = 3DConvolution kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-3DConvolution:3DConvolution.o
+3DConvolution: 3DConvolution.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-3DConvolution.o:3DConvolution.cpp
+3DConvolution.o: 3DConvolution.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./3DConvolution $(PROBLEM_SIZE)

--- a/veo/3mm/Makefile
+++ b/veo/3mm/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = 3mm kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-3mm:3mm.o
+3mm: 3mm.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-3mm.o:3mm.cpp
+3mm.o: 3mm.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./3mm $(PROBLEM_SIZE)

--- a/veo/Makefile
+++ b/veo/Makefile
@@ -1,8 +1,8 @@
 SUBDIRS := $(wildcard */.)
 
-.PHONY: all clean
+.PHONY: all clean run
 
-all clean:
+all clean run:
 	for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir -f Makefile $@; \
 	done

--- a/veo/atax/Makefile
+++ b/veo/atax/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = atax kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-atax:atax.o
+atax: atax.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-atax.o:atax.cpp
+atax.o: atax.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./atax $(PROBLEM_SIZE)

--- a/veo/bicg/Makefile
+++ b/veo/bicg/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = bicg kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-bicg:bicg.o
+bicg: bicg.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-bicg.o:bicg.cpp
+bicg.o: bicg.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./bicg $(PROBLEM_SIZE)

--- a/veo/config.mk
+++ b/veo/config.mk
@@ -1,0 +1,8 @@
+VEO_HEADER_PATH := /opt/nec/ve/veos/include
+VEO_LIB_PATH := /opt/nec/ve/veos/lib64
+VEFLAGS := -I../../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
+
+NCC := /opt/nec/ve/bin/ncc
+CXX := g++
+
+PROBLEM_SIZE := 100

--- a/veo/correlation/Makefile
+++ b/veo/correlation/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = correlation kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-correlation:correlation.o
+correlation: correlation.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-correlation.o:correlation.cpp
+correlation.o: correlation.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./correlation $(PROBLEM_SIZE)

--- a/veo/covariance/Makefile
+++ b/veo/covariance/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = covariance kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-covariance:covariance.o
+covariance: covariance.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-covariance.o:covariance.cpp
+covariance.o: covariance.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./covariance $(PROBLEM_SIZE)

--- a/veo/fdtd2d/Makefile
+++ b/veo/fdtd2d/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = fdtd2d kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-fdtd2d:fdtd2d.o
+fdtd2d: fdtd2d.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-fdtd2d.o:fdtd2d.cpp
+fdtd2d.o: fdtd2d.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./fdtd2d $(PROBLEM_SIZE)

--- a/veo/gemm/Makefile
+++ b/veo/gemm/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = gemm kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-gemm:gemm.o
+gemm: gemm.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-gemm.o:gemm.cpp
+gemm.o: gemm.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./gemm $(PROBLEM_SIZE)

--- a/veo/gesummv/Makefile
+++ b/veo/gesummv/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = gesummv kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-gesummv:gesummv.o
+gesummv: gesummv.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-gesummv.o:gesummv.cpp
+gesummv.o: gesummv.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./gesummv $(PROBLEM_SIZE)

--- a/veo/gramschmidt/Makefile
+++ b/veo/gramschmidt/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = gramschmidt kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-gramschmidt:gramschmidt.o
+gramschmidt: gramschmidt.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-gramschmidt.o:gramschmidt.cpp
+gramschmidt.o: gramschmidt.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./gramschmidt $(PROBLEM_SIZE)

--- a/veo/kmeans/Makefile
+++ b/veo/kmeans/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I ../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = kmeans kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-kmeans:kmeans.o
+kmeans: kmeans.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-kmeans.o:kmeans.cpp
+kmeans.o: kmeans.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./kmeans $(PROBLEM_SIZE)

--- a/veo/lin_reg_coeff/Makefile
+++ b/veo/lin_reg_coeff/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = lin_reg_coeff kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-lin_reg_coeff:lin_reg_coeff.o
+lin_reg_coeff: lin_reg_coeff.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-lin_reg_coeff.o:lin_reg_coeff.cpp
+lin_reg_coeff.o: lin_reg_coeff.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./lin_reg_coeff $(PROBLEM_SIZE)

--- a/veo/lin_reg_error/Makefile
+++ b/veo/lin_reg_error/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = lin_reg_error kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-lin_reg_error:lin_reg_error.o
+lin_reg_error: lin_reg_error.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-lin_reg_error.o:lin_reg_error.cpp
+lin_reg_error.o: lin_reg_error.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./lin_reg_error $(PROBLEM_SIZE)

--- a/veo/median/Makefile
+++ b/veo/median/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I ../../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = median kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-median:median.o
+median: median.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-median.o:median.cpp
+median.o: median.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./median $(PROBLEM_SIZE)

--- a/veo/mol_dyn/Makefile
+++ b/veo/mol_dyn/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = mol_dyn kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-mol_dyn:mol_dyn.o
+mol_dyn: mol_dyn.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-mol_dyn.o:mol_dyn.cpp
+mol_dyn.o: mol_dyn.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./mol_dyn $(PROBLEM_SIZE)

--- a/veo/mvt/Makefile
+++ b/veo/mvt/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = mvt kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-mvt:mvt.o
+mvt: mvt.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-mvt.o:mvt.cpp
+mvt.o: mvt.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./mvt $(PROBLEM_SIZE)

--- a/veo/scalar_prod/Makefile
+++ b/veo/scalar_prod/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = scalar_prod kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-scalar_prod:scalar_prod.o
+scalar_prod: scalar_prod.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-scalar_prod.o:scalar_prod.cpp
+scalar_prod.o: scalar_prod.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./scalar_prod $(PROBLEM_SIZE)

--- a/veo/sobel3/Makefile
+++ b/veo/sobel3/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I ../../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = sobel3 kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-sobel3:sobel3.o
+sobel3: sobel3.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-sobel3.o:sobel3.cpp
+sobel3.o: sobel3.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./sobel3 $(PROBLEM_SIZE)

--- a/veo/sobel5/Makefile
+++ b/veo/sobel5/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I ../../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = sobel5 kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-sobel5:sobel5.o
+sobel5: sobel5.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-sobel5.o:sobel5.cpp
+sobel5.o: sobel5.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./sobel5 $(PROBLEM_SIZE)

--- a/veo/sobel7/Makefile
+++ b/veo/sobel7/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I ../../include -I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = sobel7 kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-sobel7:sobel7.o
+sobel7: sobel7.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-sobel7.o:sobel7.cpp
+sobel7.o: sobel7.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./sobel7 $(PROBLEM_SIZE)

--- a/veo/syrk/Makefile
+++ b/veo/syrk/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = syrk kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-syrk:syrk.o
+syrk: syrk.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-syrk.o:syrk.cpp
+syrk.o: syrk.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./syrk $(PROBLEM_SIZE)

--- a/veo/syrk2/Makefile
+++ b/veo/syrk2/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = syrk2 kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-syrk2:syrk2.o
+syrk2: syrk2.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-syrk2.o:syrk2.cpp
+syrk2.o: syrk2.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./syrk2 $(PROBLEM_SIZE)

--- a/veo/vec_add/Makefile
+++ b/veo/vec_add/Makefile
@@ -1,22 +1,19 @@
-VEO_HEADER_PATH=/opt/nec/ve/veos/include
-VEO_LIB_PATH=/opt/nec/ve/veos/lib64
-VEFLAGS=-I$(VEO_HEADER_PATH) -lpthread -L$(VEO_LIB_PATH) -Wl,-rpath=$(VEO_LIB_PATH) -lveo
-
-NCC=/opt/nec/ve/bin/ncc
-
-CXX=g++
-# CXXFLAGS = -std=c++17 -DDEBUG 
+include ../config.mk
 
 TARGET = vec_add kernel.so
-all:$(TARGET)
+all: $(TARGET)
 
-vec_add:vec_add.o
+vec_add: vec_add.o
 	$(CXX) $< -o $@ $(VEFLAGS)
-vec_add.o:vec_add.cpp
+vec_add.o: vec_add.cpp
 	$(CXX) -c $< -o $@ $(VEFLAGS)
-kernel.so:kernel.c
+kernel.so: kernel.c
 	$(NCC) -fpic -shared -o $@ $<
 
 .PHONY: clean
 clean:
-	rm -rf *.o $(TARGET)	
+	rm -rf *.o $(TARGET)
+
+.PHONY: run
+run: $(TARGET)
+	./vec_add $(PROBLEM_SIZE)


### PR DESCRIPTION
- Place variables used for compilation (e.g. `CXX`) in `veo/config.mk` and include it from the each submake.
- Add a phony target `run`, which builds the benchmark and runs it. The problem size can be passed via the variable `PROBLEM_SIZE`.